### PR TITLE
feat: Optimize line rasterization by using a single coordinate array

### DIFF
--- a/rasterizer/lines.py
+++ b/rasterizer/lines.py
@@ -52,13 +52,13 @@ def rasterize_lines(
     x_grid_min, x_grid_max = x[0] - half_dx, x[-1] + half_dx
     y_grid_min, y_grid_max = y[0] - half_dy, y[-1] + half_dy
 
-    geoms_to_process = []
-    for geom in tqdm(lines_proj.geometry, disable=not progress_bar):
-        if isinstance(geom, MultiLineString):
-            for line in geom.geoms:
-                geoms_to_process.append(np.array(line.coords))
-        elif isinstance(geom, LineString):
-            geoms_to_process.append(np.array(geom.coords))
+    geoms_to_process = (
+        lines_proj.explode(index_parts=True)
+        .reset_index(drop=True)
+        .get_coordinates()
+        .reset_index()
+        .values
+    )
 
     raster_data_float = _rasterize_lines_engine(
         geoms_to_process,

--- a/rasterizer/numba_impl.py
+++ b/rasterizer/numba_impl.py
@@ -84,10 +84,11 @@ def _rasterize_lines_engine(
     mode_is_binary,
 ):
     raster_data = np.zeros((len(y), len(x)), dtype=np.float32)
-    for geom_coords in geoms:
-        for i in range(len(geom_coords) - 1):
-            xa, ya = geom_coords[i]
-            xb, yb = geom_coords[i + 1]
+    for i in range(len(geoms) - 1):
+        # Check if the current and next points belong to the same line
+        if geoms[i, 0] == geoms[i + 1, 0]:
+            xa, ya = geoms[i, 1], geoms[i, 2]
+            xb, yb = geoms[i + 1, 1], geoms[i + 1, 2]
 
             seg_xmin, seg_xmax = min(xa, xb), max(xa, xb)
             seg_ymin, seg_ymax = min(ya, yb), max(ya, yb)


### PR DESCRIPTION
The `rasterize_lines` function was optimized by changing the way line geometries are processed. Instead of creating a list of numpy arrays for each line or multiline part, this change uses a single numpy array for all coordinates.

This is achieved by:
1.  Exploding the `MultiLineString` geometries into individual `LineString`s.
2.  Creating a unique ID for each `LineString` part.
3.  Generating a single numpy array with columns `(line_id, x, y)`.

The `_rasterize_lines_engine` function in the numba implementation was updated to handle this new 3-column array structure. This approach is significantly faster for GeoDataFrames with a large number of line geometries.